### PR TITLE
Use a macro that does not `@eval` into ImportAll

### DIFF
--- a/src/ImportAll.jl
+++ b/src/ImportAll.jl
@@ -1,16 +1,16 @@
 module ImportAll
 
 macro importall(moduleIn, verbose=false)
-    modName = @eval($(moduleIn))
-    out = []
-    for name in names(modName)
-            symbolname = @eval $(name)
-            expression = :(import $(moduleIn): $(name))
-            push!(out, expression)
+    quote
+        try
+            $(esc(moduleIn))
+        catch
+            import $(moduleIn)
+        end
+        for name in names($(esc(moduleIn)))
+            @eval import .$(moduleIn): $(Expr(:$, :name))
+        end
     end
-	
-    ret = Expr(:block,out...)
-	return ret
 end
 
 export @importall

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,28 @@
 using Test
-using ImportAll
 
-@testset "Approximation Type" begin
+module A
+    const y = 2
+    function foo end
+    export y, foo
+end
 
- @test true
+module B
+    using ImportAll
+    import ..A
+    @importall A
+    foo(x) = x + 2
+end
 
+module C
+    using ImportAll
+    @importall Base
+    struct A end
+    iterate(::A) = nothing
+    length(::A) = 0
+end
+
+@testset "import all" begin
+    @test B.y == 2
+    @test A.foo(1) == 3
+    @test collect(C.A()) == []
 end


### PR DESCRIPTION
This change fixes incremental compilation breakage that occurs because the macro is running code in the ImportAll module at macro invocation time, which is not necessary. It is sufficient to iterate over names in the generated code, instead of generating a list of imports.

Please test for your use case; the tests only cover a very small subset of potential uses.